### PR TITLE
set_elem has changed to put_elem

### DIFF
--- a/about_tuples.exs
+++ b/about_tuples.exs
@@ -29,7 +29,7 @@ defmodule About_Tuples do
 
     think "Can set a tuple element" do
         a_tuple = {:foo, :bar}
-        baz_tuple = set_elem(a_tuple, 0, :baz)
+        baz_tuple = put_elem(a_tuple, 0, :baz)
         # Note: think about immutability
         assert elem(a_tuple, 0) == __?
         assert elem(baz_tuple, 0) == __?
@@ -38,7 +38,7 @@ defmodule About_Tuples do
     think "Setting a tuple element that not exists raise an argument error" do
         a_tuple = {:foo, :bar}
 
-        assert_raise ArgumentError, fn -> set_elem(a_tuple, __?, :baz) end
+        assert_raise ArgumentError, fn -> put_elem(a_tuple, __?, :baz) end
     end
 
     think "Can insert a tuple element" do


### PR DESCRIPTION
set_elem has been deprecated in favour of put_elem to remain consistent. See https://github.com/elixir-lang/elixir/issues/2259 for more details.