### PR TITLE
Fixes #19 - Updating about_testing with the new exception from assert

### DIFF
--- a/about_testing.exs
+++ b/about_testing.exs
@@ -29,11 +29,11 @@ defmodule About_testing do
         is_1_equal_2? = fn -> assert 1 == 2 end
         is_1_greater_than_2? = fn -> assert 1 > 2 end
 
-        message = "Expected 1 to be " <> __? <> " 2"
-        assert_raise ExUnit.ExpectationError, message, is_1_equal_2?
+        message = "Assertion with " <> __? <> " failed"
+        assert_raise ExUnit.AssertionError, message, is_1_equal_2?
 
-        message = "Expected 1 to be " <> __? <> " 2"
-        assert_raise ExUnit.ExpectationError, message, is_1_greater_than_2?
+        message = "Assertion with " <> __? <> " failed"
+        assert_raise ExUnit.AssertionError, message, is_1_greater_than_2?
     end
 end
 


### PR DESCRIPTION
The code for Elixir 1.0.4 raises ExUnit.AssertionError with a new error message:
```elixir
  def assert(value, message) when is_binary(message) do
    assert(value, message: message)
  end

  def assert(value, opts) when is_list(opts) do
    unless value, do: raise(ExUnit.AssertionError, opts)
    true
  end
```
This pull request will update about_testing.exs accordingly.