### PR TITLE
The assertion choice for string 'at' and 'slice' examples is wrong

### DIFF
--- a/about_strings.exs
+++ b/about_strings.exs
@@ -39,17 +39,17 @@ defmodule About_Strings do
 
   think "accessing letters by their positions" do
     a_string = "Hello world!"
-    assert String.at(a_string, 2), __?
-    assert String.at(a_string, 20), __?
+    assert String.at(a_string, 2) == __?
+    assert String.at(a_string, 20) == __?
   end
 
   think "slicing a string" do
     a_string = "Hello world!"
-    assert String.slice(a_string, 6, 5), __?
-    assert String.slice(a_string, -3, 6), __?
-    assert String.slice(a_string, 20, 5), __?
-    assert String.slice(a_string, 4, 0), __?
-    assert String.slice(a_string, 0..5), __?
+    assert String.slice(a_string, 6, 5) == __?
+    assert String.slice(a_string, -3, 6) == __?
+    assert String.slice(a_string, 20, 5) == __?
+    assert String.slice(a_string, 4, 0) == __?
+    assert String.slice(a_string, 0..5) == __?
   end
 
   think "capitalization" do


### PR DESCRIPTION
I was getting strange results working on the koans for `String.at` and `String.slice` until I reexamined what you taught me in about_testing and realized that testing this way would not work. Because the 2nd argument of assert is an error message to display to the user.

So changing `, __?` will just change out the error message. With `== __?` the right hand side values are properly compared to the expectations.

In the case of `assert String.at(a_string, 20), __?` changing out the `__?` will just cause syntax errors because the assertion result is nil.

Loving these koans so far by the way!