### PR TITLE
fix issue with list of integers showing as strings

### DIFF
--- a/about_enums.exs
+++ b/about_enums.exs
@@ -178,7 +178,7 @@ defmodule About_Enums do
   end
 
   think "map reduce" do
-    list = [4, 5, 6]
+    list = [2, 3, 4]
     assert Enum.map_reduce(list, 0, fn (x, acc) -> {x * 2, x + acc} end) == __?
   end
 
@@ -272,11 +272,16 @@ defmodule About_Enums do
   end
 
   think "taking some items" do
-    numbers = 1..10
+    numbers = 1..5
     assert Enum.take(numbers, 2) == __?
   end
 
   think "taking some items the other way" do
+    numbers = 1..5
+    assert Enum.take(numbers, -2) == __?
+  end
+
+  think "taking some items the other way is not always as expected" do
     numbers = 1..10
     assert Enum.take(numbers, -2) == __?
   end


### PR DESCRIPTION
For a couple of the tests in about_enums the list of integers are valid ascii characters that cause the result to be unexpected. 

For the map reduce with [4, 5, 6] the answer was coming out as: {'\b\n\f', 15}
For the take some items the other way the answer was coming out as: '\t\n'

I figured out why this was happening from the official elixir-lang FAQ: 
https://github.com/elixir-lang/elixir/wiki/FAQ#4-why-is-my-list-of-integers-printed-as-a-string

I added an additional test with the take numbers the other way to keep a test in with this unexpected result. It is fun to see these interesting cases in a new language!
